### PR TITLE
Add be_dynamic_document matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ end
 
 RSpec.describe Log do
   it { is_expected.to be_stored_in :logs }
+  it { is_expected.to be_dynamic_document }
 end
 
 RSpec.describe Article do

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -161,3 +161,13 @@ RSpec::Matchers.define :be_multiparameted_document do
     "be a multiparameted Mongoid document"
   end
 end
+
+RSpec::Matchers.define :be_dynamic_document do |_|
+  match do |doc|
+    doc.class.included_modules.include?(Mongoid::Attributes::Dynamic)
+  end
+
+  description do
+    'be a Mongoid document with dynamic attributes'
+  end
+end

--- a/spec/models/log.rb
+++ b/spec/models/log.rb
@@ -1,4 +1,6 @@
 class Log
   include Mongoid::Document
+  include Mongoid::Attributes::Dynamic
+
   store_in collection: "logs"
 end

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -18,4 +18,9 @@ RSpec.describe "Document" do
     it { is_expected.to be_mongoid_document }
     it { is_expected.to be_timestamped_document }
   end
+
+  describe Log do
+    it { is_expected.to be_mongoid_document }
+    it { is_expected.to be_dynamic_document }
+  end
 end


### PR DESCRIPTION
On my current project we intensively use `Mongoid::Attributes::Dynamic` to store responses from g+, fb, twitter, youtube. And to track such models I created `be_dynamic_document` matcher:

```ruby
class Log
  include Mongoid::Document
  include Mongoid::Attributes::Dynamic
end

RSpec.describe Log do
  it { is_expected.to be_dynamic_document }
end
```

I'm not sure if it has right name, hence any suggestions are welcome.