### PR TITLE
Add with_counter_cache relation matcher's option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ RSpec.describe Record do
 end
 
 RSpec.describe Site do
-  it { is_expected.to have_many(:users).as_inverse_of(:site).ordered_by(:email.asc) }
+  it { is_expected.to have_many(:users).as_inverse_of(:site).ordered_by(:email.asc).with_counter_cache }
 end
 ```
 

--- a/lib/matchers/associations.rb
+++ b/lib/matchers/associations.rb
@@ -101,6 +101,12 @@ module Mongoid
           self
         end
 
+        def with_counter_cache
+          @association[:counter_cache] = true
+          @expectation_message << " which specifies counter_cache as #{@association[:counter_cache].to_s}"
+          self
+        end
+
         def matches?(actual)
           @actual = actual.is_a?(Class) ? actual : actual.class
           metadata = @actual.relations[@association[:name]]
@@ -232,6 +238,15 @@ module Mongoid
               return false
             else
               @positive_result_message = "#{@positive_result_message} with foreign key #{metadata.foreign_key.inspect}"
+            end
+          end
+
+          if @association[:counter_cache]
+            if metadata.counter_cached? != true
+              @negative_result_message = "#{@positive_result_message} which did not set counter_cache"
+              return false
+            else
+              @positive_result_message = "#{@positive_result_message} which set counter_cache"
             end
           end
 

--- a/spec/models/site.rb
+++ b/spec/models/site.rb
@@ -3,7 +3,7 @@ class Site
 
   field :name
 
-  has_many :users, inverse_of: :site, order: :email.desc
+  has_many :users, inverse_of: :site, order: :email.desc, counter_cache: true
 
   validates :name, presence: true, uniqueness: true
 end

--- a/spec/unit/associations_spec.rb
+++ b/spec/unit/associations_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe "Associations" do
   end
 
   describe Site do
-    it { is_expected.to have_many(:users).as_inverse_of(:site).ordered_by(:email.desc) }
+    it { is_expected.to have_many(:users).as_inverse_of(:site).ordered_by(:email.desc).with_counter_cache }
   end
 end


### PR DESCRIPTION
It's strange that rspec-mongoid still doesn't have this matcher, maybe it's because this option isn't well documented in mongoid. 
In my code I used this method to check if relation has counter cache: https://github.com/mongoid/mongoid/blob/master/lib/mongoid/relations/metadata.rb#L149

Example: 
```ruby
class User
  include Mongoid::Document

  has_many :posts, counter_cache: true
end

RSpec.describe User do
  it { is_expected.to have_many(:posts).with_counter_cache }
end
```