### PR TITLE
Added have_enum matcher

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,1 @@
----
-BUNDLE_WITHOUT: ''
+--- {}

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "http://rubygems.org"
 
 # Specify your gem's dependencies in mongoid-rspec.gemspec
-gem 'mongoid-enum', '~> 0.3'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "http://rubygems.org"
 
 # Specify your gem's dependencies in mongoid-rspec.gemspec
+gem 'mongoid-enum', '~> 0.3'
 gemspec

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -82,13 +82,7 @@ module Mongoid
       end
     end
 
-    def have_field(*args)
-      HaveFieldMatcher.new(*args)
-    end
-    alias_method :have_fields, :have_field
-  end
-
-  class HaveEnumMatcher # :nodoc:
+    class HaveEnumMatcher # :nodoc:
       def initialize(*attrs)
         @attributes = attrs.collect(&:to_s)
       end
@@ -123,6 +117,7 @@ module Mongoid
           else
             @errors.push "no enum named #{attr.inspect}"
           end
+        
         end
         @errors.empty?
       end
@@ -145,11 +140,16 @@ module Mongoid
       end
     end
 
+    def have_field(*args)
+      HaveFieldMatcher.new(*args)
+    end
+
     def have_enum(*args)
       HaveEnumMatcher.new(*args)
     end
+    alias_method :have_fields, :have_field
     alias_method :have_enums, :have_enum
-  end
+  end    
 end
 
 RSpec::Matchers.define :have_instance_method do |name|

--- a/lib/mongoid/rspec/version.rb
+++ b/lib/mongoid/rspec/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Rspec
-    VERSION = "2.2.2"
+    VERSION = "2.2.3"
   end
 end

--- a/lib/mongoid/rspec/version.rb
+++ b/lib/mongoid/rspec/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Rspec
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end

--- a/lib/mongoid/rspec/version.rb
+++ b/lib/mongoid/rspec/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Rspec
-    VERSION = "2.2.1"
+    VERSION = "2.2.2"
   end
 end

--- a/mongoid-rspec.gemspec
+++ b/mongoid-rspec.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency 'mongoid', '>= 4.0.0'
   s.add_dependency 'rspec',   '~> 3.3'
+  s.add_development_dependency 'mongoid-enum', '~> 0.3'
 end

--- a/spec/models/article.rb
+++ b/spec/models/article.rb
@@ -1,13 +1,15 @@
 class Article
   include Mongoid::Document
   include Mongoid::Timestamps
+  include Mongoid::Enum
 
   field :title, localize: true
   field :content
   field :published, type: Boolean, default: false
   field :allow_comments, type: Boolean, default: true
   field :number_of_comments, type: Integer
-  field :status, type: Symbol
+
+  enum :status, [:pending, :approved, :declined]
 
   embeds_many :comments, cascade_callbacks: true
   embeds_one :permalink

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "bundler"
 Bundler.setup
 
 require 'mongoid'
+require 'mongoid/enum'
 require 'rspec'
 require 'rspec/core'
 require 'rspec/expectations'

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Document" do
     it { is_expected.to have_field(:title).localized }
     it { is_expected.not_to have_field(:allow_comments).of_type(Mongoid::Boolean).with_default_value_of(false) }
     it { is_expected.not_to have_field(:number_of_comments).of_type(Integer).with_default_value_of(1) }
+    it { is_expected.to have_enum(:status) }
     it { is_expected.to be_mongoid_document }
     it { is_expected.to be_timestamped_document }
   end


### PR DESCRIPTION
#### What?
Added support for https://github.com/thetron/mongoid-enum . What does lib does internally is creating an underscored property with the given name of type Symbol. Although it can be done using the current matchers, matching by the underscored name and the type Symbol I think it's much better having a custom matcher for that

```ruby
it { is_expected.to have_enum(:role) }
```