### PR TITLE
Add license flag to the gemspec

### DIFF
--- a/mongoid-rspec.gemspec
+++ b/mongoid-rspec.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = %q{http://github.com/mongoid-rspec/mongoid-rspec}
   s.summary     = %q{RSpec matchers for Mongoid}
   s.description = %q{RSpec matches for Mongoid models, including association and validation matchers}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "mongoid-rspec"
 


### PR DESCRIPTION
I picked the MIT license, as the LICENSE file looks like MIT.
I would like to add this because it will make automated license checking using [dblock/gem-license](https://github.com/dblock/gem-licenses) easier.