### PR TITLE
Remove deprecated matchers. 

### DIFF
--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -122,18 +122,6 @@ RSpec::Matchers.define :be_timestamped_document do
   end
 end
 
-# deprecated until 3.2.0
-RSpec::Matchers.define :be_multiparameted_document do
-  match do |doc|
-    warn "[DEPRECATION] `be_multiparameted_document` is deprecated.  It will be removed in mongoid-rspec 3.2.0, see https://github.com/mongoid-rspec/mongoid-rspec/issues/166"
-    doc.class.included_modules.include?(Mongoid::MultiParameterAttributes)
-  end
-
-  description do
-    "be a multiparameted Mongoid document"
-  end
-end
-
 RSpec::Matchers.define :be_dynamic_document do |_|
   match do |doc|
     doc.class.included_modules.include?(Mongoid::Attributes::Dynamic)

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -123,18 +123,6 @@ RSpec::Matchers.define :be_timestamped_document do
 end
 
 # deprecated until 3.2.0
-RSpec::Matchers.define :be_paranoid_document do
-  match do |doc|
-    warn "[DEPRECATION] `be_paranoid_document` is deprecated.  It will be removed in mongoid-rspec 3.2.0, see https://github.com/mongoid-rspec/mongoid-rspec/issues/166"
-    doc.class.included_modules.include?(Mongoid::Paranoia)
-  end
-
-  description do
-    "be a paranoid Mongoid document"
-  end
-end
-
-# deprecated until 3.2.0
 RSpec::Matchers.define :be_multiparameted_document do
   match do |doc|
     warn "[DEPRECATION] `be_multiparameted_document` is deprecated.  It will be removed in mongoid-rspec 3.2.0, see https://github.com/mongoid-rspec/mongoid-rspec/issues/166"

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -111,18 +111,6 @@ RSpec::Matchers.define :be_mongoid_document do
   end
 end
 
-# deprecated until 3.2.0
-RSpec::Matchers.define :be_versioned_document do
-  match do |doc|
-    warn "[DEPRECATION] `be_versioned_document` is deprecated.  It will be removed in mongoid-rspec 3.2.0, see https://github.com/mongoid-rspec/mongoid-rspec/issues/166"
-    doc.class.included_modules.include?(Mongoid::Versioning)
-  end
-
-  description do
-    "be a versioned Mongoid document"
-  end
-end
-
 RSpec::Matchers.define :be_timestamped_document do
   match do |doc|
     if [*@timestamped_module].any?

--- a/lib/matchers/document.rb
+++ b/lib/matchers/document.rb
@@ -89,18 +89,6 @@ module Mongoid
   end
 end
 
-# deprecated until 3.2.0
-RSpec::Matchers.define :have_instance_method do |name|
-  match do |klass|
-    warn "[DEPRECATION] `have_instance_method` is deprecated.  It will be removed in mongoid-rspec 3.2.0, see https://github.com/mongoid-rspec/mongoid-rspec/issues/166"
-    klass.instance_methods.include?(name.to_sym)
-  end
-
-  description do
-    "have instance method #{name.to_s}"
-  end
-end
-
 RSpec::Matchers.define :be_mongoid_document do
   match do |doc|
     doc.class.included_modules.include?(Mongoid::Document)

--- a/lib/mongoid/rspec/version.rb
+++ b/lib/mongoid/rspec/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Rspec
-    VERSION = '3.0.0'
+    VERSION = '4.0.0-alpha'
   end
 end


### PR DESCRIPTION
Also bumps version to 4.0.0-alpha1 in order to start work on new version of gem