### PR TITLE
Fix instance variable warnings

### DIFF
--- a/lib/matchers/have_field.rb
+++ b/lib/matchers/have_field.rb
@@ -3,6 +3,10 @@ module Mongoid
     class HaveField # :nodoc:
       def initialize(*attrs)
         @attributes = attrs.collect(&:to_s)
+        @default = nil
+        @field_alias = nil
+        @localized = nil
+        @type = nil
       end
 
       def localized

--- a/lib/matchers/have_timestamps.rb
+++ b/lib/matchers/have_timestamps.rb
@@ -7,6 +7,9 @@ module Mongoid
     class HaveTimestamps
       def initialize
         @root_module = 'Mongoid::Timestamps'
+        @phase = nil
+        @shortened = nil
+        @submodule = nil
       end
 
       def matches?(actual)


### PR DESCRIPTION
This fixes some Ruby verbose warnings

```
ruby/gems/2.4.0/bundler/gems/mongoid-rspec-f392d24abc68/lib/matchers/have_timestamps.rb:55: warning: instance variable @submodule not initialized
```